### PR TITLE
Initial Release: Install and Cache Terraform Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# terraform-plugin
-Setup and cache Terraform plugin from GitHub Actions
+![](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/last-commit/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/release-date/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/repo-size/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/issues/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/languages/top/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/github/commit-activity/m/subhamay-bhattacharyya/terraform-plugin)&nbsp;![](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/94d897b9a77f8ef1b8c3705b3916bdc2/raw/terraform-plugin.json?)
+
+# Install and Cache Terraform Plugin
+
+## Introduction
+This repository provides a script to install and cache Terraform plugins. This helps in reducing the time required to download plugins during Terraform runs.
+
+## Prerequisites
+- Terraform installed on your machine
+- Internet connection to download plugins
+
+## Installation
+1. Clone the repository:
+    ```sh
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+
+2. Run the installation script:
+    ```sh
+    ./install_plugins.sh
+    ```
+
+## Usage
+1. Ensure the plugins are cached by running the script:
+    ```sh
+    ./install_plugins.sh
+    ```
+
+2. Use Terraform as usual:
+    ```sh
+    terraform init
+    terraform apply
+    ```
+
+## Contributing
+Contributions are welcome! Please open an issue or submit a pull request.
+
+## License
+This project is licensed under the MIT License.

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,43 @@
+name: 'Install and Cache Terraform Plugin'
+description: 'Installs Terraform plugin and cache it.'
+inputs:
+  caching:
+    description: 'Whether to cache dependies or not.'
+    required: false
+    default: 'true'
+  tf-version:
+    description: 'The Terraform version to be used.'
+    required: true
+    default: 1.4
+outputs:
+  used-cache:
+    description: 'Whether the cache was used.'
+    value: ${{ steps.install.outputs.cache }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3.1.2
+      with:
+        terraform_version: inputs.tf-version
+
+    - name: Cache Terraform
+      if: inputs.caching == 'true'
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.terraform.d/plugin-cache
+        key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+        restore-keys: |
+          ${{ runner.os }}-terraform-
+
+    - name: Config Terraform plugin cache
+      id: install
+      if: steps.cache.outputs.cache-hit != 'true' || inputs.caching != 'true'
+      run: |
+        echo 'plugin_cache_dir="$HOME/.terraform.d/plugin-cache"' >~/.terraformrc
+        mkdir --parents ~/.terraform.d/plugin-cache
+        echo "cache='${{ inputs.caching }}'" >> $GITHUB_OUTPUT
+      shell: bash


### PR DESCRIPTION
## Initial Release: Install and Cache Terraform Plugin

### Introduction
This repository provides a script to install and cache Terraform plugins. This helps in reducing the time required to download plugins during Terraform runs.

### Prerequisites
- Terraform installed on your machine
- Internet connection to download plugins

### Installation
1. Clone the repository:
    ```sh
    git clone <repository-url>
    cd <repository-directory>
    ```

2. Run the installation script:
    ```sh
    ./install_plugins.sh
    ```

### Usage
1. Ensure the plugins are cached by running the script:
    ```sh
    ./install_plugins.sh
    ```

2. Use Terraform as usual:
    ```sh
    terraform init
    terraform apply
    ```

### Contributing
Contributions are welcome! Please open an issue or submit a pull request.

### License
This project is licensed under the MIT License.